### PR TITLE
raise upper bound for base to <4.15 to support ghc-8.10

### DIFF
--- a/curve25519.cabal
+++ b/curve25519.cabal
@@ -17,7 +17,7 @@ library
   exposed-modules:     Crypto.Curve25519,
                        Crypto.Curve25519.Exceptions,
                        Crypto.Curve25519.Pure
-  build-depends:       base       >= 4.6  && < 4.14,
+  build-depends:       base       >= 4.6  && < 4.15,
                        bytestring >= 0.10 && < 0.12,
                        crypto-api >= 0.10 && < 0.14
   hs-source-dirs:      src


### PR DESCRIPTION
Test suceeds on my machine.